### PR TITLE
added command node to all gmx_ calculations and added function to pri…

### DIFF
--- a/aiida_gromacs/calculations/editconf.py
+++ b/aiida_gromacs/calculations/editconf.py
@@ -7,7 +7,7 @@ import os
 
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
-from aiida.orm import SinglefileData
+from aiida.orm import SinglefileData, Str
 from aiida.plugins import DataFactory
 
 EditconfParameters = DataFactory("gromacs.editconf")
@@ -25,6 +25,11 @@ class EditconfCalculation(CalcJob):
         """Define inputs and outputs of the calculation."""
         # yapf: disable
         super().define(spec)
+
+        # Define inputs and outputs of the calculation.
+        spec.input('command',
+                valid_type=Str, required=False,
+                help='The command used to execute the job.')
 
         # set default values for AiiDA options
         # TODO: something changed about withmpi in aiida-2.4.0, needs investigation.

--- a/aiida_gromacs/calculations/genericMD.py
+++ b/aiida_gromacs/calculations/genericMD.py
@@ -40,8 +40,6 @@ class GenericCalculation(CalcJob):
             dynamic=True, # can take num of values unknown at time of definition
         )
 
-        spec.output('log', valid_type=SinglefileData, required=False,
-                help='link to the default file.out.')
 
         # set the list of output file names as an input so that it can be
         # iterated over in the parser later.

--- a/aiida_gromacs/calculations/genion.py
+++ b/aiida_gromacs/calculations/genion.py
@@ -7,7 +7,7 @@ import os
 
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
-from aiida.orm import SinglefileData
+from aiida.orm import SinglefileData, Str
 from aiida.plugins import DataFactory
 
 GenionParameters = DataFactory("gromacs.genion")
@@ -25,6 +25,11 @@ class GenionCalculation(CalcJob):
         """Define inputs and outputs of the calculation."""
         # yapf: disable
         super().define(spec)
+
+        # Define inputs and outputs of the calculation.
+        spec.input('command',
+                valid_type=Str, required=False,
+                help='The command used to execute the job.')
 
         # set default values for AiiDA options
         # TODO: something changed about withmpi in aiida-2.4.0, needs investigation.

--- a/aiida_gromacs/calculations/grompp.py
+++ b/aiida_gromacs/calculations/grompp.py
@@ -7,7 +7,7 @@ import os
 
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
-from aiida.orm import SinglefileData, FolderData
+from aiida.orm import SinglefileData, FolderData, Str
 from aiida.plugins import DataFactory
 
 GromppParameters = DataFactory("gromacs.grompp")
@@ -25,6 +25,11 @@ class GromppCalculation(CalcJob):
         """Define inputs and outputs of the calculation."""
         # yapf: disable
         super().define(spec)
+
+        # Define inputs and outputs of the calculation.
+        spec.input('command',
+                valid_type=Str, required=False,
+                help='The command used to execute the job.')
 
         # set default values for AiiDA options
         # TODO: something changed about withmpi in aiida-2.4.0, needs investigation.

--- a/aiida_gromacs/calculations/make_ndx.py
+++ b/aiida_gromacs/calculations/make_ndx.py
@@ -7,7 +7,7 @@ import os
 
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
-from aiida.orm import SinglefileData
+from aiida.orm import SinglefileData, Str
 from aiida.plugins import DataFactory
 
 Make_ndxParameters = DataFactory("gromacs.make_ndx")
@@ -25,6 +25,11 @@ class Make_ndxCalculation(CalcJob):
         """Define inputs and outputs of the calculation."""
         # yapf: disable
         super().define(spec)
+
+        # Define inputs and outputs of the calculation.
+        spec.input('command',
+                valid_type=Str, required=False,
+                help='The command used to execute the job.')
 
         # set default values for AiiDA options
         # TODO: something changed about withmpi in aiida-2.4.0, needs investigation.

--- a/aiida_gromacs/calculations/mdrun.py
+++ b/aiida_gromacs/calculations/mdrun.py
@@ -7,7 +7,7 @@ import os
 
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
-from aiida.orm import SinglefileData, Dict
+from aiida.orm import SinglefileData, Dict, Str
 from aiida.plugins import DataFactory
 
 MdrunParameters = DataFactory("gromacs.mdrun")
@@ -25,6 +25,11 @@ class MdrunCalculation(CalcJob):
         """Define inputs and outputs of the calculation."""
         # yapf: disable
         super().define(spec)
+
+        # Define inputs and outputs of the calculation.
+        spec.input('command',
+                valid_type=Str, required=False,
+                help='The command used to execute the job.')
 
         # set default values for AiiDA options
         # TODO: something changed about withmpi in aiida-2.4.0, needs investigation.

--- a/aiida_gromacs/calculations/pdb2gmx.py
+++ b/aiida_gromacs/calculations/pdb2gmx.py
@@ -7,7 +7,7 @@ import os
 
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
-from aiida.orm import SinglefileData
+from aiida.orm import SinglefileData, Str
 from aiida.plugins import DataFactory
 
 Pdb2gmxParameters = DataFactory("gromacs.pdb2gmx")
@@ -25,6 +25,11 @@ class Pdb2gmxCalculation(CalcJob):
         """Define inputs and outputs of the calculation."""
         # yapf: disable
         super().define(spec)
+
+        # Define inputs and outputs of the calculation.
+        spec.input('command',
+                valid_type=Str, required=False,
+                help='The command used to execute the job.')
 
         # set default values for AiiDA options
         # TODO: something changed about withmpi in aiida-2.4.0, needs investigation.

--- a/aiida_gromacs/calculations/solvate.py
+++ b/aiida_gromacs/calculations/solvate.py
@@ -7,7 +7,7 @@ import os
 
 from aiida.common import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
-from aiida.orm import SinglefileData
+from aiida.orm import SinglefileData, Str
 from aiida.plugins import DataFactory
 
 SolvateParameters = DataFactory("gromacs.solvate")
@@ -25,6 +25,11 @@ class SolvateCalculation(CalcJob):
         """Define inputs and outputs of the calculation."""
         # yapf: disable
         super().define(spec)
+
+        # Define inputs and outputs of the calculation.
+        spec.input('command',
+                valid_type=Str, required=False,
+                help='The command used to execute the job.')
 
         # set default values for AiiDA options
         # TODO: something changed about withmpi in aiida-2.4.0, needs investigation.

--- a/aiida_gromacs/cli/editconf.py
+++ b/aiida_gromacs/cli/editconf.py
@@ -8,7 +8,7 @@ import os
 
 import click
 
-from aiida import cmdline, engine
+from aiida import cmdline, engine, orm
 from aiida.plugins import CalculationFactory, DataFactory
 
 from aiida_gromacs import helpers
@@ -37,6 +37,9 @@ def launch(params):
     else:
         computer = helpers.get_computer()
         inputs["code"] = helpers.get_code(entry_point="gromacs", computer=computer)
+
+    # save the full command as a string in the inputs dict
+    inputs = searchprevious.save_command("gmx editconf", params, inputs)
 
     input_file_labels = {} # dict used for finding previous nodes
     input_file_labels[params["f"]] = "grofile"

--- a/aiida_gromacs/cli/genericMD.py
+++ b/aiida_gromacs/cli/genericMD.py
@@ -75,7 +75,7 @@ def launch_genericMD(options):
             "label": "generic-execute",
             "description": "Run CLI job and save input and output file provenance.",
             "options": {
-                "output_filename": f"{command.split()[0]}.out",
+                "output_filename": f"{searchprevious.format_link_label(command.split()[0])}.out",
                 "output_dir": output_dir,
                 "parser_name": "gromacs.genericMD",
             },

--- a/aiida_gromacs/cli/genericMD.py
+++ b/aiida_gromacs/cli/genericMD.py
@@ -75,7 +75,7 @@ def launch_genericMD(options):
             "label": "generic-execute",
             "description": "Run CLI job and save input and output file provenance.",
             "options": {
-                "output_filename": "file.out",
+                "output_filename": f"{command.split()[0]}.out",
                 "output_dir": output_dir,
                 "parser_name": "gromacs.genericMD",
             },

--- a/aiida_gromacs/cli/genion.py
+++ b/aiida_gromacs/cli/genion.py
@@ -8,7 +8,7 @@ import os
 
 import click
 
-from aiida import cmdline, engine
+from aiida import cmdline, engine, orm
 from aiida.plugins import CalculationFactory, DataFactory
 
 from aiida_gromacs import helpers
@@ -38,6 +38,9 @@ def launch(params):
         computer = helpers.get_computer()
         inputs["code"] = helpers.get_code(entry_point="gromacs", computer=computer)
         inputs["code"] = helpers.get_code(entry_point="bash", computer=computer)
+
+    # save the full command as a string in the inputs dict
+    inputs = searchprevious.save_command("gmx genion", params, inputs)
 
     input_file_labels = {} # dict used for finding previous nodes
     input_file_labels[params["s"]] = "tprfile"

--- a/aiida_gromacs/cli/grompp.py
+++ b/aiida_gromacs/cli/grompp.py
@@ -7,7 +7,7 @@ Usage: gmx_grompp --help
 import click
 import os
 
-from aiida import cmdline, engine
+from aiida import cmdline, engine, orm
 from aiida.plugins import CalculationFactory, DataFactory
 
 from aiida_gromacs import helpers
@@ -36,6 +36,9 @@ def launch(params):
     else:
         computer = helpers.get_computer()
         inputs["code"] = helpers.get_code(entry_point="gromacs", computer=computer)
+
+    # save the full command as a string in the inputs dict
+    inputs = searchprevious.save_command("gmx grompp", params, inputs)
 
     input_file_labels = {} # dict used for finding previous nodes
     input_file_labels[params["f"]] = "mdpfile"

--- a/aiida_gromacs/cli/make_ndx.py
+++ b/aiida_gromacs/cli/make_ndx.py
@@ -8,7 +8,7 @@ import os
 
 import click
 
-from aiida import cmdline, engine
+from aiida import cmdline, engine, orm
 from aiida.plugins import CalculationFactory, DataFactory
 
 from aiida_gromacs import helpers
@@ -38,6 +38,9 @@ def launch(params):
     else:
         computer = helpers.get_computer()
         inputs["code"] = helpers.get_code(entry_point="gromacs", computer=computer)
+
+    # save the full command as a string in the inputs dict
+    inputs = searchprevious.save_command("gmx make_ndx", params, inputs)
 
     # Prepare input parameters in AiiDA formats.
     SinglefileData = DataFactory("core.singlefile")

--- a/aiida_gromacs/cli/mdrun.py
+++ b/aiida_gromacs/cli/mdrun.py
@@ -8,7 +8,7 @@ import os
 
 import click
 
-from aiida import cmdline, engine
+from aiida import cmdline, engine, orm
 from aiida.plugins import CalculationFactory, DataFactory
 
 from aiida_gromacs import helpers
@@ -37,6 +37,9 @@ def launch(params):
     else:
         computer = helpers.get_computer()
         inputs["code"] = helpers.get_code(entry_point="gromacs", computer=computer)
+
+    # save the full command as a string in the inputs dict
+    inputs = searchprevious.save_command("gmx mdrun", params, inputs)
 
     input_file_labels = {} # dict used for finding previous nodes
     input_file_labels[params["s"]] = "tprfile"

--- a/aiida_gromacs/cli/pdb2gmx.py
+++ b/aiida_gromacs/cli/pdb2gmx.py
@@ -5,10 +5,10 @@ Usage: gmx_pdb2gmx --help
 """
 
 import os
-
+import sys
 import click
 
-from aiida import cmdline, engine
+from aiida import cmdline, engine, orm
 from aiida.plugins import CalculationFactory, DataFactory
 
 from aiida_gromacs import helpers
@@ -37,6 +37,9 @@ def launch(params):
     else:
         computer = helpers.get_computer()
         inputs["code"] = helpers.get_code(entry_point="gromacs", computer=computer)
+
+    # save the full command as a string in the inputs dict
+    inputs = searchprevious.save_command("gmx pdb2gmx", params, inputs)
 
     input_file_labels = {} # dict used for finding previous nodes
     input_file_labels[params["f"]] = "pdbfile"

--- a/aiida_gromacs/cli/print_provenance.py
+++ b/aiida_gromacs/cli/print_provenance.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""
+Show text output of the provenance of commands performed in gmx
+"""
+import click
+from aiida_gromacs.utils.displayprovenance import show_provenance_text
+
+def launch(params):
+    """Run print_provenance
+    """
+    show_provenance_text()
+
+@click.command()
+def cli(*args, **kwargs):
+    # pylint: disable=unused-argument
+    """Print out the provenance of aiida-gromacs processes run on current
+    loaded aiida profile
+
+    Example usage:
+
+    $ print_provenance
+
+    Help: $ print_provenance --help
+    """
+    launch(kwargs)
+    
+
+if __name__ == "__main__":
+    cli()  # pylint: disable=no-value-for-parameter

--- a/aiida_gromacs/cli/solvate.py
+++ b/aiida_gromacs/cli/solvate.py
@@ -8,7 +8,7 @@ import os
 
 import click
 
-from aiida import cmdline, engine
+from aiida import cmdline, engine, orm
 from aiida.plugins import CalculationFactory, DataFactory
 
 from aiida_gromacs import helpers
@@ -37,6 +37,9 @@ def launch(params):
     else:
         computer = helpers.get_computer()
         inputs["code"] = helpers.get_code(entry_point="gromacs", computer=computer)
+
+    # save the full command as a string in the inputs dict
+    inputs = searchprevious.save_command("gmx solvate", params, inputs)
 
     input_file_labels = {} # dict used for finding previous nodes
     input_file_labels[params["cp"]] = "grofile"

--- a/aiida_gromacs/parsers/genericMD.py
+++ b/aiida_gromacs/parsers/genericMD.py
@@ -76,9 +76,6 @@ class GenericParser(Parser):
         with self.retrieved.open(output_filename, "rb") as handle:
             output_node = SinglefileData(file=handle)
 
-        # return stdout file 
-        self.out("log", output_node)
-
         # passing along all expected output file as SinglefileData nodes.
         for thing in files_expected:
             self.logger.info(f"Parsing '{thing}'")

--- a/aiida_gromacs/utils/displayprovenance.py
+++ b/aiida_gromacs/utils/displayprovenance.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""
+Display provenance of processes run on current loaded profile
+"""
+
+from aiida import orm, load_profile
+
+
+def show_provenance_text():
+    """For a given loaded aiida profile, view the provenance graph on the
+    CLI as plain text
+    """
+    load_profile()
+    qb = orm.QueryBuilder()
+    # get all processes and order from oldest to newest
+    qb.append(orm.ProcessNode, tag='process')
+    qb.order_by({orm.ProcessNode: {"ctime": "asc"}})
+
+    output_pks = {}
+    for i, entry in enumerate(qb.all(flat=True)):
+        # print(list(entry.inputs))
+        # print(list(entry.outputs))
+        # print(dir(entry))
+        # print(entry.label)
+        command = ""
+        executable = ""
+        for link_triple in entry.get_incoming().all():
+            # print("A", link_triple.node)
+            # print("B", link_triple.link_type)
+            # print("C", link_triple.link_label)
+            # print("D", type(link_triple.node))
+            if link_triple.link_label == "command":
+                command = link_triple.node.value
+
+
+        incoming = entry.get_incoming().all_nodes()
+        outgoing = entry.get_outgoing().all_nodes()
+        input_files = []
+        output_files = []
+        for inputs in incoming:
+            if isinstance(inputs, orm.InstalledCode):
+                executable = inputs.label
+            if isinstance(inputs, orm.SinglefileData):
+                # file = open_file(inputs)
+                input_str = inputs.filename
+                if inputs.pk in output_pks:
+                    input_str = f"{inputs.filename} <-- from Step {output_pks[inputs.pk]}."
+                input_files.append(input_str)
+        for outputs in outgoing:
+            if outputs.pk not in output_pks:
+                output_pks[outputs.pk] = i+1 
+            if isinstance(outputs, orm.SinglefileData):
+                output_files.append(outputs.filename)
+
+        inputs_str = '\n\t\t'.join(input_files)
+        outputs_str = '\n\t\t'.join(output_files)
+        output = (
+                f"\nStep {i+1}."
+                f"\n\tcommand: {command}"
+                f"\n\texecutable: {executable}"
+                f"\n\tinput files: \n\t\t{inputs_str}"
+                f"\n\toutput files: \n\t\t{outputs_str}")
+        print(output)
+
+
+
+def open_file(file):
+    """
+    """
+    lines = None
+    try:
+        with file.open(mode='r') as handle:
+            lines = handle.readlines()
+    except UnicodeDecodeError:
+        pass
+    return lines

--- a/aiida_gromacs/utils/searchprevious.py
+++ b/aiida_gromacs/utils/searchprevious.py
@@ -176,3 +176,20 @@ def link_previous_file_nodes(input_file_labels: dict, inputs: dict):
                 label = input_file_labels[prev_output_filename]
                 inputs[label] = prev_file_node
     return inputs
+
+
+
+def save_command(executable: str, params: dict, inputs: dict):
+    """
+    For a given cli command run via aiida-gromacs, save this as a string 
+    and use this as an attribute for the given process
+    """
+
+    # save the full command as a string in the inputs dict
+    str_params = ""
+    for k, v in params.items():
+        v_stripped = strip_path(v)
+        str_params += f"-{k} {v_stripped} "
+    command = f"{executable} {str_params}"
+    inputs["command"] = orm.Str(command)
+    return inputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ gmx_solvate = "aiida_gromacs.cli.solvate:cli"
 gmx_make_ndx = "aiida_gromacs.cli.make_ndx:cli"
 genericMD = "aiida_gromacs.cli.genericMD:cli"
 createarchive = "aiida_gromacs.cli.createarchive:cli"
+print_provenance = "aiida_gromacs.cli.print_provenance:cli"
 
 [project.entry-points."aiida.data"]
 "gromacs.pdb2gmx" = "aiida_gromacs.data.pdb2gmx:Pdb2gmxParameters"


### PR DESCRIPTION
…nt provenance to screen

Once all processes are run in an aiida profile, the user can run `print_provenance` on command line and something similar to the following should print out to the terminal:


Step 1.
        command: gmx pdb2gmx -f 1AKI_clean.pdb -ff oplsaa -water spce -o 1AKI_forcefield.gro -p 1AKI_topology.top -i 1AKI_restraints.itp 
        executable: gmx
        input files: 
                1AKI_clean.pdb
        output files: 
                pdb2gmx.out
                1AKI_forcefield.gro
                1AKI_topology.top
                1AKI_restraints.itp

Step 2.
        command: gmx editconf -f 1AKI_forcefield.gro -center 0 -d 1.0 -bt cubic -o 1AKI_newbox.gro 
        executable: gmx
        input files: 
                1AKI_forcefield.gro <-- from Step 1.
        output files: 
                editconf.out
                1AKI_newbox.gro

Step 3.
        command: gmx solvate -cp 1AKI_newbox.gro -cs spc216.gro -p 1AKI_topology.top -o 1AKI_solvated.gro 
        executable: gmx
        input files: 
                1AKI_topology.top <-- from Step 1.
                1AKI_newbox.gro <-- from Step 2.
        output files: 
                solvate.out
                1AKI_solvated.gro
                1AKI_topology.top

Step 4.
        command: gmx grompp -f ions.mdp -c 1AKI_solvated.gro -p 1AKI_topology.top -o 1AKI_ions.tpr 
        executable: gmx
        input files: 
                1AKI_solvated.gro <-- from Step 3.
                1AKI_topology.top <-- from Step 3.
                ions.mdp
        output files: 
                grompp.out
                1AKI_ions.tpr