### PR TITLE
Update CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         container: [py3.11.0]
-        aiida: [2.4.0, 2.4.1, 2.4.2, 2.5.0]
-        gmx: [2023.1=nompi_h76c6bb2_100,
+        aiida: [2.4.0, 2.4.1, 2.4.2, 2.5.0, 2.5.1, 2.5.2]
+        gmx: [2023.4=nompi_h76c6bb2_103,
               2022.4=nompi_hca75aac_100]
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
Updated to cover newer versions of AiiDA and also bumped gromacs 2023.1 to 2023.4