### PR TITLE
195 gmx grompp fails for topology that lists itp files in subdirectories

### DIFF
--- a/aiida_gromacs/cli/grompp.py
+++ b/aiida_gromacs/cli/grompp.py
@@ -85,7 +85,8 @@ def launch(params):
 
             # Now fill it with files referenced in the topology.
             inputs["itp_dirs"][itp_file.split("/")[0]].put_object_from_file(
-                os.path.join(os.getcwd(), itp_file), path=itp_file.split("/")[-1])
+                os.path.join(os.getcwd(), itp_file), path=itp_file) #.split("/")[-1])
+
 
     if "r" in params:
         inputs["r_file"] = SinglefileData(file=os.path.join(os.getcwd(), params.pop("r")))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 keywords = ["aiida", "plugin", "gromacs", "aiida-gromacs"]
 requires-python = ">=3.8"
 dependencies = [
-    "aiida-core>=2.4.0,<3",
+    "aiida-core>=2.5.0,<3",
     "voluptuous"
 ]
 


### PR DESCRIPTION
The full path (folder name + file name) of the file to be added into FolderData() is required for latest version of aiida (2.6.3). This is a breaking change and will not work for aiida-core < 2.5.0.