### PR TITLE
update version to 2.1.0, a breaking change

### DIFF
--- a/aiida_gromacs/__init__.py
+++ b/aiida_gromacs/__init__.py
@@ -4,4 +4,4 @@ aiida_gromacs
 A plugin for using GROMACS with AiiDA for molecular dymanics simulations.
 """
 
-__version__ = "2.0.10"
+__version__ = "2.1.0"


### PR DESCRIPTION
Have a look at issue #195 for why this a breaking change, briefly, the full path to  itp files in a folder is required to move to remote in AiiDA version 2.6.3