### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every day
+      interval: "daily"
+      time: "09:00"
+      timezone: "UTC"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         image: harbor.stfc.ac.uk/psdi-pathfinder4/aiida-testbase:${{ matrix.container }}
     name: ${{ matrix.container }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
 
     - name: Start AiiDA with a test profile
       shell: bash
@@ -34,17 +34,17 @@ jobs:
       run: pytest --cov aiida_gromacs --cov-report term-missing --cov-append .
 
     - name: Report Coverage
-      uses: coverallsapp/github-action@v2
+      uses: coverallsapp/github-action@v2.3.6
 
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4.2.2
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5.6.0
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install python dependencies
       run: |
         pip install --upgrade pip
@@ -56,11 +56,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+    - uses: actions/checkout@v4.2.2
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5.6.0
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install python dependencies
       run: |
         pip install --upgrade pip


### PR DESCRIPTION
Enable dependabot and set it to keep the actions workflow components up to date.

Add more verbose version numbers, so instead of some-action:v5, we now have full version number. 

The former would allow updates to latest versions within an major series to happen invisibly, so if issues occur in the CI flow debugging is opaque. Since CI is generally triggered when code changes happen, the natural first course would be that the code changed caused the issue and not a silent action update. 

This change will improve verbosity of updating infrastructure.

Bump python used in docs and pre-commit to 3.12
